### PR TITLE
Remove invalid VirtualBox option for Linux

### DIFF
--- a/Vagrantfile-linux.template
+++ b/Vagrantfile-linux.template
@@ -17,7 +17,6 @@ Vagrant.configure("2") do |config|
     virtualbox.customize ["modifyvm", :id, "--cpus", 2]
     virtualbox.customize ["modifyvm", :id, "--audiocontroller", "hda"]
     virtualbox.customize ["modifyvm", :id, "--memory", 2048]
-    virtualbox.customize ["modifyvm", :id, "--accelerate2dvideo", "on"]
     virtualbox.customize ["modifyvm", :id, "--vram", 128]
     virtualbox.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
   end


### PR DESCRIPTION
The option accelerate2dvideo has no effect for Linux VMs in VirtualBox, because it is intended to be used in Windows VMs. Because of this, VirtualBox shows a warning saying the option is invalid when you enter the VM settings.