### PR TITLE
fix(docs): add unzip to dependencies/requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ with Packer.
 
   ```bash
   sudo apt update
-  sudo apt install -y ansible curl git jq libc6-dev libvirt-daemon-system libvirt-dev python3-winrm qemu-kvm sshpass virtualbox
+  sudo apt install -y ansible curl git jq libc6-dev libvirt-daemon-system libvirt-dev python3-winrm qemu-kvm sshpass unzip virtualbox
 
   PACKER_LATEST_VERSION="$(curl -s https://checkpoint-api.hashicorp.com/v1/check/packer | jq -r -M '.current_version')"
   curl "https://releases.hashicorp.com/packer/${PACKER_LATEST_VERSION}/packer_${PACKER_LATEST_VERSION}_linux_amd64.zip" --output /tmp/packer_linux_amd64.zip
@@ -156,7 +156,7 @@ with Packer.
 
   ```bash
   sudo dnf install https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
-  sudo dnf install -y ansible curl git jq libvirt libvirt-devel qemu-kvm ruby-devel VirtualBox
+  sudo dnf install -y ansible curl git jq libvirt libvirt-devel qemu-kvm ruby-devel unzip VirtualBox
 
   PACKER_LATEST_VERSION="$(curl -s https://checkpoint-api.hashicorp.com/v1/check/packer | jq -r -M '.current_version')"
   curl "https://releases.hashicorp.com/packer/${PACKER_LATEST_VERSION}/packer_${PACKER_LATEST_VERSION}_linux_amd64.zip" --output /tmp/packer_linux_amd64.zip


### PR DESCRIPTION
Hi, First of all, Thank you for this repository :+1: 

Whilst following the setup instructions, i found that my system was missing the `unzip` command, which is needed to install packer, via unzipping it into `/usr/local/bin/`.
```
sudo unzip /tmp/packer_linux_amd64.zip -d /usr/local/bin/
```
It's just a small thing, and I was not paying to much attention whilst copy and pasting the commands, took me a few minutes or so to find it ^^.

Maybe this PR will prevent many more minutes to go to waste.

Greetings.
KeyboardInterrupt