### PR TITLE
#332 Setup OpenSSH Portable for windows

### DIFF
--- a/ansible/win-simple.yml
+++ b/ansible/win-simple.yml
@@ -3,6 +3,7 @@
 
   vars:
     bleachbit_url: https://download.bleachbit.org/BleachBit-4.4.0-portable.zip
+    openssh_url: https://github.com/PowerShell/Win32-OpenSSH/releases/download/V8.6.0.0p1-Beta/OpenSSH-Win64.zip
 
   roles:
     - role: ansible-role-virtio-win
@@ -56,6 +57,31 @@
         dest: "%HOMEDRIVE%\\BleachBit-portable.zip"
       register: result
       until: result is succeeded
+
+    - name: Download OpenSSH
+      win_get_url:
+        url: "{{ openssh_url }}"
+        dest: "%HOMEDRIVE%\\OpenSSH-portable.zip"
+      register: result
+      until: result is succeeded
+
+    - name: Unzip downloaded OpenSSH
+      win_unzip:
+        src: "%HOMEDRIVE%\\OpenSSH-portable.zip"
+        dest: "%HOMEDRIVE%\\"
+        delete_archive: yes
+
+    - name: Install OpenSSH
+      win_shell: "C:\\OpenSSH-Win64\\install-sshd.ps1"
+
+    - name: Set OpenSSH Service to automatic startup and ensure it is up
+      win_service:
+        name: sshd
+        start_mode: auto
+        state: started
+
+    - name: Enable Firewall for OpenSSH
+      win_shell: New-NetFirewallRule -DisplayName "ssh" -Direction Inbound -Action Allow -Protocol "TCP" -LocalPort "22"
 
     - name: Unzip downloaded BleachBit
       win_unzip:


### PR DESCRIPTION
Install OpenSSH Portable for windows, which can be used for provisioning as an alternative to winrm
on libvirt based setups.

While by default, winrm is used, users can enable the ssh communicator using the following settings within the
Vagrantfile:

```
  config.vm.communicator = "winssh"                                                                                                                                                            
  config.ssh.password = "vagrant"  # required to allow vagrant to add ssh key during first step
  config.vm.provision "shell",
    inline: "Write hello"

```
As virtual machine spins up, connection is attempted and provisioning scripts are executed via
SSH:

```
==> default: Starting domain.
==> default: Waiting for domain to get an IP address...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 10.0.0.10:22
    default: SSH username: vagrant
    default: SSH auth method: password
    default: Warning: Connection reset. Retrying...
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Forwarding ports...
==> default: 3389 (guest) => 3389 (host) (adapter eth0)
==> default: 5986 (guest) => 5986 (host) (adapter eth0)
==> default: 5985 (guest) => 5985 (host) (adapter eth0)
==> default: Running provisioner: shell...
    default: Running: inline script
    default: 
    default: hello
```