### PR TITLE
Updated README.md with new URL for Fedora install

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ with Packer.
   rm /tmp/packer_linux_amd64.zip
 
   VAGRANT_LATEST_VERSION=$(curl -s https://checkpoint-api.hashicorp.com/v1/check/vagrant | jq -r -M '.current_version')
-  sudo dnf install -y https://releases.hashicorp.com/vagrant/${VAGRANT_LATEST_VERSION}/vagrant_${VAGRANT_LATEST_VERSION}_x86_64.rpm
+  sudo dnf install -y https://releases.hashicorp.com/vagrant/${VAGRANT_LATEST_VERSION}/vagrant-${VAGRANT_LATEST_VERSION}-1.x86_64.rpm
   CONFIGURE_ARGS="with-ldflags=-L/opt/vagrant/embedded/lib with-libvirt-include=/usr/include/libvirt with-libvirt-lib=/usr/lib64/libvirt" vagrant plugin install vagrant-libvirt
 
   sudo gpasswd -a ${USER} kvm ; sudo gpasswd -a ${USER} libvirt ; sudo gpasswd -a ${USER} vboxusers


### PR DESCRIPTION
The Fedora URL for install had underscores instead of dashes. The bad URL causes an error for the user. See screenshot attached.

![vagrant-fedora-error](https://user-images.githubusercontent.com/7544799/205183763-60a36cfc-0a78-4878-927d-a6aa4c6d8d61.png)

![Screenshot from 2022-12-01 18-56-38](https://user-images.githubusercontent.com/7544799/205183900-4324aa76-f1b6-4ecf-bc34-d7f555dc3e81.png)
